### PR TITLE
feat: Add shimmering loading skeletons to district dashboard (Closes #10)

### DIFF
--- a/src/app/district/[slug]/loading.tsx
+++ b/src/app/district/[slug]/loading.tsx
@@ -1,0 +1,64 @@
+import { Header } from '@/components/ui/header';
+import { Footer } from '@/components/ui/footer';
+import Skeleton from '@/components/ui/skeleton-card';
+
+export default function Loading() {
+    return (
+        <>
+            <Header />
+            <main className="min-h-screen bg-gradient-to-br from-nature-50 via-white to-sky-50 pb-20">
+                <section className="max-w-6xl mx-auto px-6 pt-10">
+                    {/* Page Header Skeleton */}
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+                        <div className="space-y-3">
+                            <Skeleton className="h-4 w-48" />
+                            <Skeleton className="h-10 w-96" />
+                            <Skeleton className="h-4 w-64" />
+                        </div>
+                        <div className="flex gap-3">
+                            <Skeleton className="h-12 w-40 rounded-full" />
+                            <Skeleton className="h-12 w-40 rounded-full" />
+                        </div>
+                    </div>
+
+                    {/* Summary Cards Grid Skeleton */}
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-10">
+                        {[...Array(4)].map((_, i) => (
+                            <div key={i} className="bg-white rounded-2xl p-5 shadow border border-gray-100 h-32 flex flex-col justify-center space-y-3">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-8 w-32" />
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* Main Content Area Skeleton */}
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
+                        <div className="bg-white rounded-2xl p-6 shadow border border-gray-100 h-96">
+                            <Skeleton className="h-6 w-64 mb-6" />
+                            <div className="space-y-4">
+                                {[...Array(5)].map((_, i) => (
+                                    <div key={i} className="flex justify-between border-b border-gray-50 pb-3">
+                                        <Skeleton className="h-4 w-40" />
+                                        <Skeleton className="h-4 w-24" />
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="bg-white rounded-2xl p-6 shadow border border-gray-100 h-96">
+                             <Skeleton className="h-6 w-64 mb-6" />
+                             <div className="space-y-4">
+                                <Skeleton className="h-4 w-full" />
+                                <Skeleton className="h-4 w-3/4" />
+                                <Skeleton className="h-4 w-5/6" />
+                                <Skeleton className="h-4 w-full mt-4" />
+                                <Skeleton className="h-4 w-2/3" />
+                             </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
+            <Footer />
+        </>
+    );
+}

--- a/src/components/ui/district-results.tsx
+++ b/src/components/ui/district-results.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { DistrictDetail } from '@/lib/types';
 import { formatCompactNumber, formatNumber, getAQICategory } from '@/lib/utils/helpers';
 import { validateDataSource, formatDataSource, getReliabilityColor } from '@/lib/data-sources/validation';
+import Skeleton from "@/components/ui/skeleton-card";
 
 interface DistrictResultsProps {
   data: DistrictDetail;
@@ -282,3 +283,74 @@ export function DistrictResults({ data }: DistrictResultsProps) {
   );
 }
 
+export function DistrictResultsSkeleton() {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+      {/* Header Skeleton */}
+      <div className="bg-gray-50 px-6 py-5 border-b border-gray-200">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-64" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-24 rounded-md" />
+            <Skeleton className="h-9 w-24 rounded-md" />
+          </div>
+        </div>
+      </div>
+
+      {/* Summary Cards Skeleton */}
+      <div className="p-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="bg-gray-50 rounded-xl p-4 border border-gray-200 h-32 flex flex-col justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="w-8 h-8 rounded-lg" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+              <Skeleton className="h-8 w-24" />
+              <Skeleton className="h-3 w-12" />
+            </div>
+          ))}
+        </div>
+
+        {/* Oxygen Analysis Skeleton */}
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm mb-6">
+          <div className="flex items-center gap-3 mb-6">
+            <Skeleton className="w-10 h-10 rounded-lg" />
+            <div className="space-y-2">
+              <Skeleton className="h-6 w-48" />
+              <Skeleton className="h-3 w-32" />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="p-4 rounded-lg bg-gray-50 border border-gray-100 h-24 flex flex-col justify-between">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Detailed Breakdown Skeleton */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+           {[...Array(2)].map((_, i) => (
+             <div key={i} className="bg-gray-50 rounded-lg p-5 border border-gray-200 h-64">
+               <Skeleton className="h-5 w-48 mb-6" />
+               <div className="space-y-4">
+                 {[...Array(4)].map((_, j) => (
+                   <div key={j} className="flex justify-between">
+                     <Skeleton className="h-4 w-32" />
+                     <Skeleton className="h-4 w-20" />
+                   </div>
+                 ))}
+               </div>
+             </div>
+           ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton-card.tsx
+++ b/src/components/ui/skeleton-card.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 
-const SkeletonCard: React.FC = () => {
-  return (
-    <div className="w-full text-left px-4 py-3 text-sm flex flex-col border-b border-gray-100 last:border-b-0">
-      <div className="space-y-1.5">
-        {/* Placeholder for district name (bold, medium font) */}
-        <div className="relative h-5 w-3/4 overflow-hidden rounded bg-gray-200">
-          <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/40 to-transparent animate-[shimmer_1.5s_infinite]" />
-        </div>
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
 
-        {/* Placeholder for state/population (small text) */}
-        <div className="relative h-3.5 w-2/3 overflow-hidden rounded bg-gray-200">
-          <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/40 to-transparent animate-[shimmer_1.5s_infinite]" />
-        </div>
-      </div>
+export default function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded bg-gray-200 ${className || ""}`}
+      {...props}
+    >
+      <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/40 to-transparent animate-[shimmer_1.5s_infinite]" />
     </div>
   );
-};
-
-export default SkeletonCard;
+}


### PR DESCRIPTION
Changes Made

Updated SkeletonCard: Refactored src/components/ui/skeleton-card.tsx to be a generic, reusable primitive that accepts custom className props for flexible sizing.

Added DistrictResultsSkeleton: Created a new skeleton component in src/components/ui/district-results.tsx that mirrors the exact layout of the real data card (including the header, grid cards, and oxygen analysis section).

Implemented loading.tsx: Added src/app/district/[slug]/loading.tsx to automatically trigger the skeleton state during server-side data fetching.

Closes #10 