### PR TITLE
Make trees count an editable number input

### DIFF
--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -69,10 +69,33 @@ export default function CalculatorPage() {
                                 <label className="text-gray-400 text-xs font-bold uppercase tracking-widest mb-2">
                                     Trees Planted
                                 </label>
-                                <div className="flex items-baseline gap-2">
-                                    <span className="text-6xl font-bold text-gray-900 tracking-tight">
-                                        {trees.toLocaleString()}
-                                    </span>
+                                <div className="flex items-baseline gap-2 justify-center">
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        max="10000"
+                                        value={trees}
+                                        onChange={(e) => {
+                                            const val = e.target.value;
+                                            // Allow empty string purely for typing experience, but otherwise parse
+                                            if (val === '') {
+                                                setTrees(0); // Temporary state for empty input
+                                                return;
+                                            }
+                                            const num = parseInt(val);
+                                            if (!isNaN(num)) {
+                                                setTrees(num);
+                                            }
+                                        }}
+                                        onBlur={() => {
+                                            // Clamp on blur
+                                            let final = Math.max(1, Math.min(10000, trees));
+                                            if (trees === 0) final = 1; // Handle empty/zero case
+                                            setTrees(final);
+                                        }}
+                                        className="text-6xl font-bold text-gray-900 tracking-tight bg-transparent text-center w-48 sm:w-64 border-b-2 border-transparent hover:border-gray-200 focus:border-green-500 focus:outline-none transition-all placeholder-gray-200 appearance-none m-0 p-0 leading-none"
+                                        style={{ MozAppearance: 'textfield' }} // Remove spin buttons Firefox
+                                    />
                                     <span className="text-xl text-gray-500 font-medium">trees</span>
                                 </div>
                             </div>
@@ -118,8 +141,8 @@ export default function CalculatorPage() {
                                             key={preset}
                                             onClick={() => setTrees(preset)}
                                             className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-all border ${trees === preset
-                                                    ? 'bg-green-600 text-white border-green-600 shadow-sm'
-                                                    : 'bg-white text-gray-600 border-gray-200 hover:border-green-300 hover:text-green-700'
+                                                ? 'bg-green-600 text-white border-green-600 shadow-sm'
+                                                : 'bg-white text-gray-600 border-gray-200 hover:border-green-300 hover:text-green-700'
                                                 }`}
                                         >
                                             {preset.toLocaleString()}
@@ -275,6 +298,12 @@ export default function CalculatorPage() {
                     border-radius: 50%;
                     cursor: pointer;
                     border: none;
+                }
+                /* Remove spinner buttons from number input */
+                input[type=number]::-webkit-inner-spin-button, 
+                input[type=number]::-webkit-outer-spin-button { 
+                    -webkit-appearance: none; 
+                    margin: 0; 
                 }
             `}</style>
         </>


### PR DESCRIPTION
Replace the static trees count display with a number input so users can type a custom tree count. Adds min/max attributes (1–10000), onChange handling that accepts an empty string during typing (temporarily sets 0) and parses numeric input, and onBlur clamping that enforces the 1–10000 range (treating empty/zero as 1). Adds styling for a large, centered input (including Firefox MozAppearance fix) and CSS to remove spinner buttons in WebKit browsers. Minor whitespace/formatting adjustment to the preset button class logic; preset behavior remains unchanged

🚀 Changes
Modified 
src/app/calculator/page.tsx :
-Replaced the static text display with a <input type="number" /> field.
-Implemented two-way data binding between the numeric input and the existing range slider.
-Added validation logic:
-Added responsive styling:

Related Issues
Issues: #47 