### PR TITLE
feat: add pagination to leaderboard (#11)

### DIFF
--- a/scripts/seed-leaderboard.ts
+++ b/scripts/seed-leaderboard.ts
@@ -1,0 +1,265 @@
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+// Create __dirname equivalent for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load environment variables from .env.local
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
+
+// Initialize Firebase Admin using environment variables
+const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY?.replace(/\\n/g, '\n');
+
+if (!projectId || !clientEmail || !privateKey) {
+    console.error('❌ Error: Missing Firebase Admin environment variables');
+    console.error('Make sure your .env.local file has the required Firebase credentials');
+    process.exit(1);
+}
+
+let adminApp;
+if (!getApps().length) {
+    adminApp = initializeApp({
+        credential: cert({
+            projectId,
+            clientEmail,
+            privateKey,
+        }),
+    });
+} else {
+    adminApp = getApps()[0];
+}
+
+const adminDb = getFirestore(adminApp);
+
+// Sample leaderboard data for Indian states
+const leaderboardData = [
+    {
+        state: 'Maharashtra',
+        population: 125000000,
+        totalTreesPlanted: 450000,
+        totalTreesDonated: 120000,
+        totalTrees: 570000,
+        existingForestTrees: 12500000,
+        existingForestO2Production: 750000,
+        forestCoverKm2: 28750,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 450000,
+        o2Supply: 125000,
+        totalO2Supply: 875000,
+        percentageMet: 194,
+        avgAQI: 85,
+        avgSoilQuality: 72,
+        rank: 1,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Karnataka',
+        population: 68000000,
+        totalTreesPlanted: 320000,
+        totalTreesDonated: 95000,
+        totalTrees: 415000,
+        existingForestTrees: 9200000,
+        existingForestO2Production: 550000,
+        forestCoverKm2: 22100,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 380000,
+        o2Supply: 115000,
+        totalO2Supply: 665000,
+        percentageMet: 175,
+        avgAQI: 72,
+        avgSoilQuality: 78,
+        rank: 2,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Tamil Nadu',
+        population: 72000000,
+        totalTreesPlanted: 280000,
+        totalTreesDonated: 85000,
+        totalTrees: 365000,
+        existingForestTrees: 8100000,
+        existingForestO2Production: 486000,
+        forestCoverKm2: 19500,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 400000,
+        o2Supply: 101000,
+        totalO2Supply: 587000,
+        percentageMet: 147,
+        avgAQI: 95,
+        avgSoilQuality: 65,
+        rank: 3,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Uttar Pradesh',
+        population: 240000000,
+        totalTreesPlanted: 150000,
+        totalTreesDonated: 45000,
+        totalTrees: 195000,
+        existingForestTrees: 5200000,
+        existingForestO2Production: 312000,
+        forestCoverKm2: 12500,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 840000,
+        o2Supply: 54000,
+        totalO2Supply: 366000,
+        percentageMet: 44,
+        avgAQI: 120,
+        avgSoilQuality: 55,
+        rank: 4,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Delhi',
+        population: 32000000,
+        totalTreesPlanted: 95000,
+        totalTreesDonated: 28000,
+        totalTrees: 123000,
+        existingForestTrees: 1500000,
+        existingForestO2Production: 90000,
+        forestCoverKm2: 3600,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 112000,
+        o2Supply: 34000,
+        totalO2Supply: 124000,
+        percentageMet: 111,
+        avgAQI: 160,
+        avgSoilQuality: 42,
+        rank: 5,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Rajasthan',
+        population: 82000000,
+        totalTreesPlanted: 210000,
+        totalTreesDonated: 62000,
+        totalTrees: 272000,
+        existingForestTrees: 7400000,
+        existingForestO2Production: 444000,
+        forestCoverKm2: 17800,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 286000,
+        o2Supply: 75000,
+        totalO2Supply: 519000,
+        percentageMet: 181,
+        avgAQI: 110,
+        avgSoilQuality: 58,
+        rank: 6,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'West Bengal',
+        population: 100000000,
+        totalTreesPlanted: 175000,
+        totalTreesDonated: 52000,
+        totalTrees: 227000,
+        existingForestTrees: 6800000,
+        existingForestO2Production: 408000,
+        forestCoverKm2: 16400,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 350000,
+        o2Supply: 63000,
+        totalO2Supply: 471000,
+        percentageMet: 135,
+        avgAQI: 125,
+        avgSoilQuality: 60,
+        rank: 7,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Telangana',
+        population: 42000000,
+        totalTreesPlanted: 125000,
+        totalTreesDonated: 38000,
+        totalTrees: 163000,
+        existingForestTrees: 4200000,
+        existingForestO2Production: 252000,
+        forestCoverKm2: 12100,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 147000,
+        o2Supply: 45000,
+        totalO2Supply: 297000,
+        percentageMet: 202,
+        avgAQI: 92,
+        avgSoilQuality: 70,
+        rank: 8,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Haryana',
+        population: 30000000,
+        totalTreesPlanted: 88000,
+        totalTreesDonated: 26000,
+        totalTrees: 114000,
+        existingForestTrees: 1800000,
+        existingForestO2Production: 108000,
+        forestCoverKm2: 4350,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 105000,
+        o2Supply: 32000,
+        totalO2Supply: 140000,
+        percentageMet: 133,
+        avgAQI: 140,
+        avgSoilQuality: 52,
+        rank: 9,
+        lastUpdated: new Date(),
+    },
+    {
+        state: 'Punjab',
+        population: 32000000,
+        totalTreesPlanted: 72000,
+        totalTreesDonated: 21000,
+        totalTrees: 93000,
+        existingForestTrees: 1600000,
+        existingForestO2Production: 96000,
+        forestCoverKm2: 3850,
+        forestDataYear: 2024,
+        forestDataSource: 'FSI India',
+        o2Needed: 112000,
+        o2Supply: 26000,
+        totalO2Supply: 122000,
+        percentageMet: 109,
+        avgAQI: 135,
+        avgSoilQuality: 48,
+        rank: 10,
+        lastUpdated: new Date(),
+    },
+];
+
+async function seedLeaderboard() {
+    try {
+        console.log('🌱 Seeding leaderboard data...');
+
+        const leaderboardRef = adminDb.collection('leaderboard');
+
+        for (const data of leaderboardData) {
+            const docId = data.state.toLowerCase().replace(/\s+/g, '-');
+            await leaderboardRef.doc(docId).set(data, { merge: true });
+            console.log(`✓ Added: ${data.state} (Rank: ${data.rank})`);
+        }
+
+        console.log('\n✅ Leaderboard seeding completed!');
+        console.log(`📊 Total states added: ${leaderboardData.length}`);
+        console.log('🚀 Visit http://localhost:3000/leaderboard to see pagination in action');
+    } catch (error) {
+        console.error('❌ Error seeding leaderboard:', error);
+        process.exit(1);
+    }
+}
+
+seedLeaderboard();

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Link } from '@/i18n/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
-
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Header } from '@/components/ui/header';
 import { Footer } from '@/components/ui/footer';
@@ -10,18 +10,18 @@ import { LeaderboardEntry } from '@/lib/types';
 import { formatCompactNumber } from '@/lib/utils/helpers';
 import { VALIDATED_DATA_SOURCES } from '@/lib/data-sources/validation';
 import { ENVIRONMENTAL_CONSTANTS } from '@/lib/constants/environmental';
-import { AlertCircle, RefreshCw } from 'lucide-react';
+import { AlertCircle, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
 
-async function getLeaderboard(): Promise<{ data?: LeaderboardEntry[]; error?: string }> {
+async function getLeaderboard(page: number, pageSize: number): Promise<{ data?: LeaderboardEntry[]; total?: number; totalPages?: number; error?: string }> {
     try {
-        const res = await fetch('/api/leaderboard', {
+        const res = await fetch(`/api/leaderboard?page=${page}&pageSize=${pageSize}`, {
             cache: 'no-store',
         });
         if (!res.ok) {
             throw new Error(`Failed to fetch leaderboard: ${res.status}`);
         }
         const data = await res.json();
-        return { data };
+        return { data: data.data, total: data.total, totalPages: data.totalPages };
     } catch (error) {
         return { error: error instanceof Error ? error.message : 'Unknown error occurred' };
     }
@@ -29,26 +29,47 @@ async function getLeaderboard(): Promise<{ data?: LeaderboardEntry[]; error?: st
 
 export default function LeaderboardPage() {
     const t = useTranslations('leaderboard');
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [showDataSources, setShowDataSources] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [totalPages, setTotalPages] = useState(0);
+
+    useEffect(() => {
+        const pageParam = Math.max(1, parseInt(searchParams?.get('page') || '1', 10));
+        const sizeParam = Math.min(50, Math.max(10, parseInt(searchParams?.get('pageSize') || '10', 10)));
+        setPage(pageParam);
+        setPageSize(sizeParam);
+    }, [searchParams]);
 
     useEffect(() => {
         const fetchData = async () => {
             setLoading(true);
             setError(null);
-            const result = await getLeaderboard();
+            const result = await getLeaderboard(page, pageSize);
             if (result.error) {
                 setError(result.error);
                 setEntries([]);
             } else {
                 setEntries(result.data || []);
+                setTotalPages(result.totalPages || 0);
             }
             setLoading(false);
         };
         fetchData();
-    }, []);
+    }, [page, pageSize]);
+
+    const handlePageChange = (newPage: number) => {
+        router.push(`?page=${newPage}&pageSize=${pageSize}`);
+    };
+
+    const handlePageSizeChange = (newSize: number) => {
+        router.push(`?page=1&pageSize=${newSize}`);
+    };
 
     return (
         <>
@@ -286,6 +307,45 @@ export default function LeaderboardPage() {
                             </table>
                         </div>
                     </div>
+
+                    {/* Pagination Controls */}
+                    {!loading && !error && entries.length > 0 && (
+                        <div className="mt-6 flex flex-col sm:flex-row items-center justify-between gap-4">
+                            <div className="flex items-center gap-2">
+                                <span className="text-sm text-gray-600 dark:text-gray-400">Rows per page:</span>
+                                <select
+                                    value={pageSize}
+                                    onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+                                    className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm"
+                                >
+                                    <option value={10}>10</option>
+                                    <option value={25}>25</option>
+                                    <option value={50}>50</option>
+                                </select>
+                            </div>
+
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={() => handlePageChange(page - 1)}
+                                    disabled={page === 1 || loading}
+                                    className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    <ChevronLeft className="w-5 h-5" />
+                                </button>
+                                <span className="text-sm text-gray-600 dark:text-gray-400 min-w-fit">
+                                    Page {page} of {totalPages}
+                                </span>
+                                <button
+                                    onClick={() => handlePageChange(page + 1)}
+                                    disabled={page === totalPages || loading}
+                                    className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                >
+                                    <ChevronRight className="w-5 h-5" />
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
                     <div className="mt-8 space-y-3 bg-gray-50 dark:bg-gray-800 p-5 rounded-lg border border-gray-200 dark:border-gray-700">
                         <div className="flex items-center justify-between">
                             <p className="text-sm font-medium text-gray-900 dark:text-gray-100">

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -35,19 +35,26 @@ export default function LeaderboardPage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [showDataSources, setShowDataSources] = useState(false);
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
     const [totalPages, setTotalPages] = useState(0);
+    const [total, setTotal] = useState(0);
+    const [pageCache, setPageCache] = useState<Record<string, LeaderboardEntry[]>>({});
 
-    useEffect(() => {
-        const pageParam = Math.max(1, parseInt(searchParams?.get('page') || '1', 10));
-        const sizeParam = Math.min(50, Math.max(10, parseInt(searchParams?.get('pageSize') || '10', 10)));
-        setPage(pageParam);
-        setPageSize(sizeParam);
-    }, [searchParams]);
+    // Get page and pageSize from URL
+    const page = Math.max(1, parseInt(searchParams?.get('page') || '1', 10));
+    const pageSize = Math.min(50, Math.max(10, parseInt(searchParams?.get('pageSize') || '10', 10)));
 
+    // Single fetch effect - read from searchParams directly
     useEffect(() => {
         const fetchData = async () => {
+            const cacheKey = `${page}-${pageSize}`;
+
+            // Check cache first
+            if (pageCache[cacheKey]) {
+                setEntries(pageCache[cacheKey]);
+                setLoading(false);
+                return;
+            }
+
             setLoading(true);
             setError(null);
             const result = await getLeaderboard(page, pageSize);
@@ -57,11 +64,17 @@ export default function LeaderboardPage() {
             } else {
                 setEntries(result.data || []);
                 setTotalPages(result.totalPages || 0);
+                setTotal(result.total || 0);
+                // Cache this page
+                setPageCache((prev) => ({
+                    ...prev,
+                    [cacheKey]: result.data || [],
+                }));
             }
             setLoading(false);
         };
         fetchData();
-    }, [page, pageSize]);
+    }, [page, pageSize, pageCache]);
 
     const handlePageChange = (newPage: number) => {
         router.push(`?page=${newPage}&pageSize=${pageSize}`);
@@ -70,6 +83,10 @@ export default function LeaderboardPage() {
     const handlePageSizeChange = (newSize: number) => {
         router.push(`?page=1&pageSize=${newSize}`);
     };
+
+    // Calculate showing text
+    const startItem = (page - 1) * pageSize + 1;
+    const endItem = Math.min(page * pageSize, total);
 
     return (
         <>
@@ -310,38 +327,65 @@ export default function LeaderboardPage() {
 
                     {/* Pagination Controls */}
                     {!loading && !error && entries.length > 0 && (
-                        <div className="mt-6 flex flex-col sm:flex-row items-center justify-between gap-4">
-                            <div className="flex items-center gap-2">
-                                <span className="text-sm text-gray-600 dark:text-gray-400">Rows per page:</span>
-                                <select
-                                    value={pageSize}
-                                    onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                                    className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm"
-                                >
-                                    <option value={10}>10</option>
-                                    <option value={25}>25</option>
-                                    <option value={50}>50</option>
-                                </select>
+                        <div className="mt-6 space-y-4">
+                            {/* Showing text */}
+                            <div className="text-sm text-gray-600 dark:text-gray-400">
+                                Showing {startItem}–{endItem} of {total}
                             </div>
 
-                            <div className="flex items-center gap-2">
-                                <button
-                                    onClick={() => handlePageChange(page - 1)}
-                                    disabled={page === 1 || loading}
-                                    className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                                >
-                                    <ChevronLeft className="w-5 h-5" />
-                                </button>
-                                <span className="text-sm text-gray-600 dark:text-gray-400 min-w-fit">
-                                    Page {page} of {totalPages}
-                                </span>
-                                <button
-                                    onClick={() => handlePageChange(page + 1)}
-                                    disabled={page === totalPages || loading}
-                                    className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                                >
-                                    <ChevronRight className="w-5 h-5" />
-                                </button>
+                            {/* Controls */}
+                            <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+                                <div className="flex items-center gap-2">
+                                    <span className="text-sm text-gray-600 dark:text-gray-400">Rows per page:</span>
+                                    <select
+                                        value={pageSize}
+                                        onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+                                        className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm"
+                                    >
+                                        <option value={10}>10</option>
+                                        <option value={25}>25</option>
+                                        <option value={50}>50</option>
+                                    </select>
+                                </div>
+
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        onClick={() => handlePageChange(page - 1)}
+                                        disabled={page === 1 || loading}
+                                        className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                    >
+                                        <ChevronLeft className="w-5 h-5" />
+                                    </button>
+
+                                    {/* Page numbers */}
+                                    <div className="flex items-center gap-1">
+                                        {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                                            const pageNum = i + 1;
+                                            return (
+                                                <button
+                                                    key={pageNum}
+                                                    onClick={() => handlePageChange(pageNum)}
+                                                    disabled={loading}
+                                                    className={`px-3 py-2 rounded-lg text-sm transition-colors ${
+                                                        page === pageNum
+                                                            ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
+                                                            : 'border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                                    }`}
+                                                >
+                                                    {pageNum}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+
+                                    <button
+                                        onClick={() => handlePageChange(page + 1)}
+                                        disabled={page === totalPages || loading}
+                                        className="p-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                    >
+                                        <ChevronRight className="w-5 h-5" />
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     )}

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -11,24 +11,27 @@ export async function GET(request: Request) {
         const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
         const pageSize = Math.min(50, Math.max(10, parseInt(searchParams.get('pageSize') || '10', 10)));
 
-        // Fetch all valid entries
-        const snapshot = await adminDb.collection('leaderboard')
+        // Get total count
+        const countSnapshot = await adminDb.collection('leaderboard')
             .orderBy('rank', 'asc')
             .get();
 
-        const allEntries = snapshot.docs
-            .map((doc: QueryDocumentSnapshot) => ({
-                id: doc.id,
-                ...doc.data()
-            } as LeaderboardEntry))
-            .filter((entry) => entry.state && entry.state.trim().length > 0);
+        const allDocs = countSnapshot.docs.filter((doc) => {
+            const data = doc.data();
+            return data.state && data.state.trim().length > 0;
+        });
 
-        const totalCount = allEntries.length;
+        const totalCount = allDocs.length;
         const totalPages = Math.ceil(totalCount / pageSize);
-        const startIdx = (page - 1) * pageSize;
-        const endIdx = startIdx + pageSize;
 
-        const leaderboard = allEntries.slice(startIdx, endIdx);
+        // Server-side pagination: skip to the page offset
+        const startIdx = (page - 1) * pageSize;
+        const paginatedDocs = allDocs.slice(startIdx, startIdx + pageSize);
+
+        const leaderboard = paginatedDocs.map((doc: QueryDocumentSnapshot) => ({
+            id: doc.id,
+            ...doc.data()
+        } as LeaderboardEntry));
 
         return NextResponse.json({
             data: leaderboard,

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -8,24 +8,35 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: Request) {
     try {
         const { searchParams } = new URL(request.url);
-        const limitParam = parseInt(searchParams.get('limit') || '35', 10);
+        const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+        const pageSize = Math.min(50, Math.max(10, parseInt(searchParams.get('pageSize') || '10', 10)));
 
-        // Simple optimized query: fetched pre-calculated ranks
-        // This reduces reads from ~1000+ (all districts) to just the number of states (requested limit)
+        // Fetch all valid entries
         const snapshot = await adminDb.collection('leaderboard')
             .orderBy('rank', 'asc')
-            .limit(limitParam)
             .get();
 
-        const leaderboard = snapshot.docs
+        const allEntries = snapshot.docs
             .map((doc: QueryDocumentSnapshot) => ({
                 id: doc.id,
                 ...doc.data()
             } as LeaderboardEntry))
-            // Filter out invalid entries without state names
             .filter((entry) => entry.state && entry.state.trim().length > 0);
 
-        return NextResponse.json(leaderboard, {
+        const totalCount = allEntries.length;
+        const totalPages = Math.ceil(totalCount / pageSize);
+        const startIdx = (page - 1) * pageSize;
+        const endIdx = startIdx + pageSize;
+
+        const leaderboard = allEntries.slice(startIdx, endIdx);
+
+        return NextResponse.json({
+            data: leaderboard,
+            total: totalCount,
+            page,
+            pageSize,
+            totalPages
+        }, {
             headers: {
                 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600',
             },


### PR DESCRIPTION
## Description
Implements pagination for the state leaderboard to improve performance and UX as requested in #11.

## Changes
- **Backend API** (`src/app/api/leaderboard/route.ts`):
  - Added `page` and `pageSize` query parameters
  - Returns paginated data with metadata (total, totalPages)
  
- **Frontend UI** (`src/app/[locale]/leaderboard/page.tsx`):
  - Added pagination controls (Previous/Next buttons)
  - Added rows per page selector (10, 25, 50)
  - URL query parameters for bookmarking (?page=X&pageSize=Y)
  - Mobile responsive design

- **Test Data Script** (`scripts/seed-leaderboard.ts`):
  - Helper script to populate leaderboard with sample state data

## Testing
- ✅ Pagination controls render correctly
- ✅ Page navigation works
- ✅ Page size selector works
- ✅ URL bookmarking works
- ✅ Mobile responsive

## Screenshot
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/5f75442c-9f3b-4c75-b75a-effd98d33501" />

## Closes
Closes #11